### PR TITLE
feat: Bun support at dev time

### DIFF
--- a/.github/workflows/versions-match.yml
+++ b/.github/workflows/versions-match.yml
@@ -14,14 +14,14 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Set up Node
-        uses: actions/setup-node@v3
+      - name: Set up Bun
+        uses: antongolub/action-setup-bun@v1.13.1
         with:
-          node-version: 18.x
-          cache: "npm"
+          bun-version: 1.0.2
+          cache: true
 
-      - name: Install Dependencies
-        run: npm ci
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
 
       - name: Check versions Match
-        run: npm run release
+        run: bun ./scripts/release.ts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.1] - 2023-09-13
+
+### Added
+
+- Support for running development scripts with `bun`.
+
+### Removed
+
+- Notice in README that there's "nothing here". There is, in fact, something here, lol.
+
 ## [0.1.0] - 2023-09-13
 
 ### Added
@@ -18,5 +28,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial boilerplate.
 
+[0.1.1]: https://github.com/AverageHelper/hono-superstruct-validator/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/AverageHelper/hono-superstruct-validator/compare/v0.0.1...v0.1.0
 [0.0.1]: https://github.com/AverageHelper/hono-superstruct-validator/releases/tag/v0.0.1

--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@ Validator middleware using [Superstruct](https://docs.superstructjs.org) for [Ho
 
 You can write a schema with Superstruct and validate the incoming values.
 
-> This project is currently in development. There is currently nothing here.
-
 ## Usage
 
 ```ts

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "hono-superstruct-validator",
-	"version": "0.1.0",
+	"version": "0.1.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "hono-superstruct-validator",
-			"version": "0.1.0",
+			"version": "0.1.1",
 			"license": "MIT",
 			"devDependencies": {
 				"@types/source-map-support": "0.5.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "hono-superstruct-validator",
-	"version": "0.1.0",
+	"version": "0.1.1",
 	"description": "Validator middleware using Superstruct.",
 	"private": false,
 	"scripts": {

--- a/scripts/assertTsNode.ts
+++ b/scripts/assertTsNode.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env ts-node
 
 /**
- * Asserts (on import) that the running context is ts-node.
+ * Asserts (on import) that the running context is ts-node or Bun.
  *
  * @throws an {@link EvalError} if the `ts-node` Service instance is not found on the process.
  *
@@ -21,7 +21,7 @@ declare global {
 	}
 }
 
-let detectTSNode = false;
+let detectTSNode = "Bun" in globalThis;
 
 try {
 	if (process[REGISTER_INSTANCE]) {


### PR DESCRIPTION
- Permit dev scripts to run under `Bun` as well as `ts-node`.
- Start using Bun in CI.
- Remove scary note from README.